### PR TITLE
Fix scope of messageHandler

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -136,6 +136,7 @@ var TelegramEmbed = function (_Component) {
       var _this2 = this;
 
       window.addEventListener('message', this.messageHandler);
+      this.messageHandler = this.messageHandler.bind(this);
 
       this.iFrame.addEventListener('load', function () {
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,8 @@ class TelegramEmbed extends Component {
 
   componentDidMount() {
     window.addEventListener('message', this.messageHandler)
-
+    this.messageHandler = this.messageHandler.bind(this);
+    
     this.iFrame.addEventListener('load', () => {
 
       this.checkFrame(this.state.id)


### PR DESCRIPTION
When creating TelegramEmbed with ReactDOM.render messageHandler is losing component scope and `this.iFrame` in messageHandler become undefined