### PR TITLE
fix messageHandler scope

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -124,7 +124,7 @@ var TelegramEmbed = function (_Component) {
       id: '',
       height: '80px'
     };
-
+    _this.messageHandler = _this.messageHandler.bind(_this);
     _this.urlObj = document.createElement('a');
 
     return _this;

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ class TelegramEmbed extends Component {
       id: '',
       height: '80px'
     }
-
+    this.messageHandler = this.messageHandler.bind(this);
     this.urlObj = document.createElement('a')
 
   }


### PR DESCRIPTION
When creating TelegramEmbed with `ReactDOM.render` messageHandler is losing component scope and `this.iFrame` in messageHandler become undefined